### PR TITLE
removes the `RABBITMQ_MANAGERBINDIP` config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Available variables:
  - `RABBITMQ_NODEPORT`: Node port. Default: **5672**
  - `RABBITMQ_CLUSTERNODENAME`: Node name to cluster with. E.g.: **clusternode@hostname**
  - `RABBITMQ_MANAGERPORT`: Manager port. Default: **15672**
- - `RABBITMQ_MANAGERBINDIP`: Manager bind ip. Default: **0.0.0.0**
 
 ## Setting up a cluster
 

--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -22,7 +22,6 @@ export RABBITMQ_NODETYPE=${RABBITMQ_NODETYPE:-"stats"}
 export RABBITMQ_NODEPORT=${RABBITMQ_NODEPORT:-"5672"}
 export RABBITMQ_NODENAME=${RABBITMQ_NODENAME:-"rabbit"}
 export RABBITMQ_MANAGERPORT=${RABBITMQ_MANAGERPORT:-"15672"}
-export RABBITMQ_MANAGERBINDIP=${RABBITMQ_MANAGERBINDIP:-"0.0.0.0"}
 
 if [[ "$1" == "harpoon" && "$2" == "start" ]] ||  [[ "$1" == "/init.sh" ]]; then
    initialize rabbitmq

--- a/rootfs/rabbitmq-inputs.json
+++ b/rootfs/rabbitmq-inputs.json
@@ -7,6 +7,5 @@
   "nodePort": "{{$global.env.RABBITMQ_NODEPORT}}",
   "nodeName": "{{$global.env.RABBITMQ_NODENAME}}",
   "clusterNodeName": "{{$global.env.RABBITMQ_CLUSTERNODENAME}}",
-  "managerPort": "{{$global.env.RABBITMQ_MANAGERPORT}}",
-  "managerBindIp": "{{$global.env.RABBITMQ_MANAGERBINDIP}}"
+  "managerPort": "{{$global.env.RABBITMQ_MANAGERPORT}}"
 }


### PR DESCRIPTION
My take is that `RABBITMQ_MANAGERBINDIP` is a extraneous param when rabbitmq is launched inside a container as the externally visible ports are controlled using `-p/--publish` arg while launching the container.