### PR TITLE
Change nodeName default value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/stacksmith-images/minideb:jessie-r2
 MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=rabbitmq \
-    BITNAMI_IMAGE_VERSION=3.6.6-r0 \
+    BITNAMI_IMAGE_VERSION=3.6.6-r1 \
     PATH=/opt/bitnami/erlang/bin:/opt/bitnami/rabbitmq/bin:$PATH
 
 # Additional modules required

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Available variables:
  - `RABBITMQ_PASSWORD`: RabbitMQ application password. Default: **bitnami**
  - `RABBITMQ_VHOST`: RabbitMQ application vhost. Default: **/**
  - `RABBITMQ_ERLANG_COOKIE`: Erlang cookie to determine whether different nodes are allowed to communicate with each other.
- - `RABBITMQ_NODE_TYPE`: Node Type. Valid values: *stats*, **queue-ram* or *queue-disc*. Default: **stats**
- - `RABBITMQ_NODE_NAME`: Node name. E.g.: *node@hostname* or *node* (If you don't specify the hostname, the env variables will be used.). Default **rabbit**
+ - `RABBITMQ_NODE_TYPE`: Node Type. Valid values: *stats*, *queue-ram* or *queue-disc*. Default: **stats**
+ - `RABBITMQ_NODE_NAME`: Node name and host. E.g.: *node@hostname* or *node* (localhost won't work in cluster topology). Default **rabbit@localhost**
  - `RABBITMQ_NODE_PORT`: Node port. Default: **5672**
  - `RABBITMQ_CLUSTER_NODE_NAME`: Node name to cluster with. E.g.: **clusternode@hostname**
  - `RABBITMQ_MANAGER_PORT`: Manager port. Default: **15672**

--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -20,7 +20,7 @@ export RABBITMQ_USERNAME=${RABBITMQ_USERNAME:-"user"}
 export RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD:-"bitnami"}
 export RABBITMQ_NODE_TYPE=${RABBITMQ_NODE_TYPE:-"stats"}
 export RABBITMQ_NODE_PORT=${RABBITMQ_NODE_PORT:-"5672"}
-export RABBITMQ_NODE_NAME=${RABBITMQ_NODE_NAME:-"rabbit"}
+export RABBITMQ_NODE_NAME=${RABBITMQ_NODE_NAME:-"rabbit@localhost"}
 export RABBITMQ_MANAGER_PORT=${RABBITMQ_MANAGER_PORT:-"15672"}
 
 if [[ "$1" == "nami" && "$2" == "start" ]] ||  [[ "$1" == "/init.sh" ]]; then


### PR DESCRIPTION
- nodeName is set to rabbit@localhost to fix a bug when restoring a previous deployment

```
application_1  | Error description:
application_1  |    {could_not_start,rabbit,
application_1  |        {{failed_to_cluster_with,
application_1  |             [rabbit@44a4bb66fbdb],
application_1  |             "Mnesia could not connect to any nodes."},
application_1  |         {rabbit,start,[normal,[]]}}}
application_1  |
application_1  | Log files (may contain more information):
application_1  |    /opt/bitnami/rabbitmq/var/log/rabbitmq/rabbit.log
application_1  |    /opt/bitnami/rabbitmq/var/log/rabbitmq/rabbit-sasl.log
```

The previous node name will change if we don't stick it to something reachable. In cluster deployments, they will be resolved inside the container network. In single-node deployment, it is needed to be localhost or the service name inside the local network.