### PR TITLE
Set default ulimit.

### DIFF
--- a/3.6/rootfs/app-entrypoint.sh
+++ b/3.6/rootfs/app-entrypoint.sh
@@ -8,7 +8,7 @@ print_welcome_page
 if [[ "${RABBIT_ULIMIT}" ]]; then
     ulimit -n "${RABBIT_ULIMIT}"
 else
-    ulimit -n 1024
+    ulimit -n 65536
 fi
 
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then

--- a/3.6/rootfs/app-entrypoint.sh
+++ b/3.6/rootfs/app-entrypoint.sh
@@ -5,6 +5,12 @@
 
 print_welcome_page
 
+if [[ "${RABBIT_ULIMIT}" ]]; then
+    ulimit -n "${RABBIT_ULIMIT}"
+else
+    ulimit -n 1024
+fi
+
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then
   nami_initialize rabbitmq
   info "Starting rabbitmq... "

--- a/3.7/rootfs/app-entrypoint.sh
+++ b/3.7/rootfs/app-entrypoint.sh
@@ -8,7 +8,7 @@ print_welcome_page
 if [[ "${RABBIT_ULIMIT}" ]]; then
     ulimit -n "${RABBIT_ULIMIT}"
 else
-    ulimit -n 1024
+    ulimit -n 65536
 fi
 
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then

--- a/3.7/rootfs/app-entrypoint.sh
+++ b/3.7/rootfs/app-entrypoint.sh
@@ -5,6 +5,12 @@
 
 print_welcome_page
 
+if [[ "${RABBIT_ULIMIT}" ]]; then
+    ulimit -n "${RABBIT_ULIMIT}"
+else
+    ulimit -n 1024
+fi
+
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then
   nami_initialize rabbitmq
   info "Starting rabbitmq... "


### PR DESCRIPTION
**Description of the change**

Set a default ulimit

**Benefits**

Stops rabbitmq form hogging file handles and causing the CPU to go through the roof when idle.

We were seeing this running rabbitmq from the helm chart on kops on AWS backed by a persistent volume.

**Possible drawbacks**

May impact performance in some scenarios, but the limit set should be adequate

**Applicable issues**

https://groups.google.com/forum/#!topic/rabbitmq-users/hO06SB-QBqc

This thread seems to describe the issue we are seeing.


I am not sure if there is a better way to integrate a change like this into your images/tooling.