### PR TITLE
Add RABBITMQ_ULIMIT_NOFILES with default value

### DIFF
--- a/3.6/rootfs/app-entrypoint.sh
+++ b/3.6/rootfs/app-entrypoint.sh
@@ -6,6 +6,8 @@
 print_welcome_page
 
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then
+  . /init.sh
+
   nami_initialize rabbitmq
   info "Starting rabbitmq... "
 fi

--- a/3.6/rootfs/init.sh
+++ b/3.6/rootfs/init.sh
@@ -1,0 +1,5 @@
+# set defaults
+export RABBITMQ_ULIMIT_NOFILES=${RABBITMQ_ULIMIT_NOFILES:-65536}
+
+# apply resources limits
+ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"

--- a/3.7/rootfs/app-entrypoint.sh
+++ b/3.7/rootfs/app-entrypoint.sh
@@ -6,6 +6,8 @@
 print_welcome_page
 
 if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then
+  . /init.sh
+
   nami_initialize rabbitmq
   info "Starting rabbitmq... "
 fi

--- a/3.7/rootfs/init.sh
+++ b/3.7/rootfs/init.sh
@@ -1,0 +1,5 @@
+# set defaults
+export RABBITMQ_ULIMIT_NOFILES=${RABBITMQ_ULIMIT_NOFILES:-65536}
+
+# apply resources limits
+ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Available variables:
  - `RABBITMQ_CLUSTER_PARTITION_HANDLING`: Cluster partition recovery mechanism. Default: **ignore**
  - `RABBITMQ_MANAGER_PORT_NUMBER`: Manager port. Default: **15672**
  - `RABBITMQ_DISK_FREE_LIMIT`: Disk free space limit of the partition on which RabbitMQ is storing data. Default: **{mem_relative, 1.0}**
+ - `RABBITMQ_ULIMIT_NOFILES`: Resources limits: maximum number of open file descriptors. Default: **65536**
 
 ## Setting up a cluster
 


### PR DESCRIPTION
**Description of the change**

Add `RABBITMQ_ULIMIT_NOFILES` environment variable with a default value (`65536`), and call `ulimit -n ${RABBITMQ_ULIMIT_NOFILES}` at startup.

**Benefits**

The default value helps work around an erlang bug which leads to high CPU usage:
https://groups.google.com/forum/#!topic/rabbitmq-users/hO06SB-QBqc

We were seeing this running rabbitmq from the helm chart on kubernetes (GKE).

**Possible drawbacks**

May impact performance in some scenarios, but the default limit set should be adequate, and is configurable.

**Applicable issues**

- https://groups.google.com/forum/#!topic/rabbitmq-users/hO06SB-QBqc
- https://github.com/kubernetes/charts/issues/3855
