### PR TITLE
supporting setting password via SHA256 hash

### DIFF
--- a/3.7/ol-7/rootfs/app-entrypoint.sh
+++ b/3.7/ol-7/rootfs/app-entrypoint.sh
@@ -9,6 +9,8 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then
   . /init.sh
   nami_initialize rabbitmq
   info "Starting rabbitmq... "
+  /set_sha256_passwd.sh --sleep 5 1>&2 >/dev/stderr &
+  disown
 fi
 
 exec tini -- "$@"

--- a/3.7/ol-7/rootfs/set_sha256_passwd.sh
+++ b/3.7/ol-7/rootfs/set_sha256_passwd.sh
@@ -2,16 +2,23 @@
 
 set -e
 
-if [[ "$1" == "--sleep" ]]; then
-  sleep $2
-fi
-
 if [[ -r /opt/bitnami/base/helpers ]]; then
   . /opt/bitnami/base/helpers
 else
   info()  { echo >&2 "INFO: $@"; }
   warn()  { echo >&2 "WARNING: $@"; }
   error() { echo >&2 "ERROR: $@"; }
+fi
+
+info "Node type \"$RABBITMQ_NODE_TYPE\" detected"
+if [[ "$RABBITMQ_NODE_TYPE" == "stats" ]]; then
+  info 'Checking environment for RABBITMQ_PASSWORD_SHA256 variable'
+else
+  info 'nothing to do here..'
+fi
+
+if [[ "$1" == "--sleep" ]]; then
+  sleep $2
 fi
 
 # details on rabbitMQ password hashing

--- a/3.7/ol-7/rootfs/set_sha256_passwd.sh
+++ b/3.7/ol-7/rootfs/set_sha256_passwd.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$1" == "--sleep" ]]; then
+  sleep $2
+fi
+
+if [[ -r /opt/bitnami/base/helpers ]]; then
+  . /opt/bitnami/base/helpers
+else
+  info()  { echo >&2 "INFO: $@"; }
+  warn()  { echo >&2 "WARNING: $@"; }
+  error() { echo >&2 "ERROR: $@"; }
+fi
+
+# details on rabbitMQ password hashing
+## https://www.rabbitmq.com/passwords.html#computing-password-hash
+#
+# Example RABBITMQ_PASSWORD_SHA256
+## plain  : bitnami256
+## SHA256 : dBfy7O8HZa1/E/KOHLB5Weu4e38bcDcUPxiFW1dLLqbx3Pag
+
+if [[ "x${RABBITMQ_PASSWORD_SHA256:-x}x" == "xxx" ]]; then
+  warn 'RABBITMQ_PASSWORD_SHA256 environment variable is not set, nothing to do here..'
+  exit 0
+else
+  warn 'RABBITMQ_PASSWORD_SHA256 environment variable detected'
+  warn "  going to use it to set password for \"${RABBITMQ_USERNAME}\""
+fi
+
+attempt_ttl=30
+curl_auth="${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}"
+api_url="http://localhost:${RABBITMQ_MANAGER_PORT_NUMBER}/api"
+
+time_start=$(date +%s)
+
+passwd_payload=$(cat <<EOM
+{
+  "password_hash":"${RABBITMQ_PASSWORD_SHA256}",
+  "tags":"administrator"
+}
+EOM
+)
+
+curl_cmd="curl -sS -o /dev/null -u ${curl_auth} -w %{http_code}"
+
+whoami() {
+  $curl_cmd ${api_url}/whoami | grep -q 200
+}
+
+set_passwd() {
+  $curl_cmd -X PUT -d "${passwd_payload}" ${api_url}/users/${RABBITMQ_USERNAME} | grep -q 204
+}
+
+while ! whoami; do
+  if [[ ${attempt_ttl:-0} -lt 1 ]]; then
+    seconds_trying=$(( $(date +%s)-$time_start ))
+    error "failed to authenticate with default credentials after $seconds_trying seconds trying, exiting.."
+    exit 1
+  fi
+  let attempt_ttl--
+  warn "failed to authenticate using default user/pass, ${attempt_ttl} attempt(s) remaining.." 
+  sleep 1
+done
+
+if set_passwd; then
+  info "\"${RABBITMQ_USERNAME}\" password set using SHA256 \"${RABBITMQ_PASSWORD_SHA256}\""
+  exit 0
+else
+  error "could not update password for \"${RABBITMQ_USERNAME}\", exiting.."
+  exit 2
+fi

--- a/3.7/rootfs/app-entrypoint.sh
+++ b/3.7/rootfs/app-entrypoint.sh
@@ -9,6 +9,8 @@ if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "/init.sh" ]]; then
   . /init.sh
   nami_initialize rabbitmq
   info "Starting rabbitmq... "
+  /set_sha256_passwd.sh --sleep 5 1>&2 >/dev/stderr &
+  disown
 fi
 
 exec tini -- "$@"

--- a/3.7/rootfs/set_sha256_passwd.sh
+++ b/3.7/rootfs/set_sha256_passwd.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-if [[ "$1" == "--sleep" ]]; then
-  sleep $2
-fi
-
 if [[ -r /opt/bitnami/base/helpers ]]; then
   . /opt/bitnami/base/helpers
 else
@@ -14,11 +10,22 @@ else
   error() { echo >&2 "ERROR: $@"; }
 fi
 
+info "Node type \"$RABBITMQ_NODE_TYPE\" detected"
+if [[ "$RABBITMQ_NODE_TYPE" == "stats" ]]; then
+  info 'Checking environment for RABBITMQ_PASSWORD_SHA256 variable'
+else
+  info 'nothing to do here..'
+fi
+
+if [[ "$1" == "--sleep" ]]; then
+  sleep $2
+fi
+
 # details on rabbitMQ password hashing
 ## https://www.rabbitmq.com/passwords.html#computing-password-hash
 #
 # Example RABBITMQ_PASSWORD_SHA256
-## plain  : bitnamisha256
+## plain  : bitnami256
 ## SHA256 : dBfy7O8HZa1/E/KOHLB5Weu4e38bcDcUPxiFW1dLLqbx3Pag
 
 if [[ "x${RABBITMQ_PASSWORD_SHA256:-x}x" == "xxx" ]]; then

--- a/3.7/rootfs/set_sha256_passwd.sh
+++ b/3.7/rootfs/set_sha256_passwd.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$1" == "--sleep" ]]; then
+  sleep $2
+fi
+
+if [[ -r /opt/bitnami/base/helpers ]]; then
+  . /opt/bitnami/base/helpers
+else
+  info()  { echo >&2 "INFO: $@"; }
+  warn()  { echo >&2 "WARNING: $@"; }
+  error() { echo >&2 "ERROR: $@"; }
+fi
+
+# details on rabbitMQ password hashing
+## https://www.rabbitmq.com/passwords.html#computing-password-hash
+#
+# Example RABBITMQ_PASSWORD_SHA256
+## plain  : bitnamisha256
+## SHA256 : dBfy7O8HZa1/E/KOHLB5Weu4e38bcDcUPxiFW1dLLqbx3Pag
+
+if [[ "x${RABBITMQ_PASSWORD_SHA256:-x}x" == "xxx" ]]; then
+  warn 'RABBITMQ_PASSWORD_SHA256 environment variable is not set, nothing to do here..'
+  exit 0
+else
+  warn 'RABBITMQ_PASSWORD_SHA256 environment variable detected'
+  warn "  going to use it to set password for \"${RABBITMQ_USERNAME}\""
+fi
+
+attempt_ttl=30
+curl_auth="${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}"
+api_url="http://localhost:${RABBITMQ_MANAGER_PORT_NUMBER}/api"
+
+time_start=$(date +%s)
+
+passwd_payload=$(cat <<EOM
+{
+  "password_hash":"${RABBITMQ_PASSWORD_SHA256}",
+  "tags":"administrator"
+}
+EOM
+)
+
+curl_cmd="curl -sS -o /dev/null -u ${curl_auth} -w %{http_code}"
+
+whoami() {
+  $curl_cmd ${api_url}/whoami | grep -q 200
+}
+
+set_passwd() {
+  $curl_cmd -X PUT -d "${passwd_payload}" ${api_url}/users/${RABBITMQ_USERNAME} | grep -q 204
+}
+
+while ! whoami; do
+  if [[ ${attempt_ttl:-0} -lt 1 ]]; then
+    seconds_trying=$(( $(date +%s)-$time_start ))
+    error "failed to authenticate with default credentials after $seconds_trying seconds trying, exiting.."
+    exit 1
+  fi
+  let attempt_ttl--
+  warn "failed to authenticate using default user/pass, ${attempt_ttl} attempt(s) remaining.." 
+  sleep 1
+done
+
+if set_passwd; then
+  info "\"${RABBITMQ_USERNAME}\" password set using SHA256 \"${RABBITMQ_PASSWORD_SHA256}\""
+  exit 0
+else
+  error "could not update password for \"${RABBITMQ_USERNAME}\", exiting.."
+  exit 2
+fi

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Available variables:
 
  - `RABBITMQ_USERNAME`: RabbitMQ application username. Default: **user**
  - `RABBITMQ_PASSWORD`: RabbitMQ application password. Default: **bitnami**
+ - `RABBITMQ_PASSWORD256`: RabbitMQ application password [SHA256 hashed](https://www.rabbitmq.com/passwords.html#computing-password-hash). Optional. Example: **dBfy7O8HZa1/E/KOHLB5Weu4e38bcDcUPxiFW1dLLqbx3Pag** (bitnami256)
  - `RABBITMQ_VHOST`: RabbitMQ application vhost. Default: **/**
  - `RABBITMQ_ERL_COOKIE`: Erlang cookie to determine whether different nodes are allowed to communicate with each other.
  - `RABBITMQ_NODE_TYPE`: Node Type. Valid values: *stats*, *queue-ram* or *queue-disc*. Default: **stats**
@@ -423,13 +424,19 @@ $ docker-compose up rabbitmq
 
 # Notable changes
 
+## 3.7.6-r10 / 3.7.6-ol-7-r5
+
+`RABBITMQ_PASSWORD_SHA256` parameter have been added. If set, it's using `RABBITMQ_PASSWORD`, to reset password
+for `RABBITMQ_USERNAME` via [RabbitMQ-Management API](https://cdn.rawgit.com/rabbitmq/rabbitmq-management/v3.7.6/priv/www/api/index.html) during start.
+
+
 ## 3.6.5-r2
 
 The following parameters have been renamed:
 
 |            From            |              To              |
 |----------------------------|------------------------------|
-| `RABBITMQ_ERLANG_COOKIE`    | `RABBITMQ_ERL_COOKIE`     |
+| `RABBITMQ_ERLANG_COOKIE`   | `RABBITMQ_ERL_COOKIE`        |
 
 ## 3.6.5-r2
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Introducing `RABBITMQ_PASSWORD_SHA256` environmental variable.  
If set, it uses `RABBITMQ_PASSWORD`, to reset password for `RABBITMQ_USERNAME` via [Rabbitmq-management plugin API](https://cdn.rawgit.com/rabbitmq/rabbitmq-management/v3.7.6/priv/www/api/index.html).

**Benefits**
No more plain text passwords passed via CLI, or elsewhere (for example: K8s manifest)

**Possible drawbacks**
Wonky bash script doing the work.. 

**Applicable issues**
- #74

**Additional Information**
See [yet another variant of python script generating RabbitMQ SHA256](https://gist.github.com/anapsix/4c3e8a8685ce5a3f0d7599c9902fd0d5)