### PR TITLE
Force no-cache of HTTPS

### DIFF
--- a/3.8/debian-10/rootfs/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/librabbitmq.sh
@@ -185,7 +185,8 @@ EOF
   },
   {rabbitmq_management,
     [
-      {listener, [{port, $RABBITMQ_MANAGER_PORT_NUMBER}, {ip, "$RABBITMQ_MANAGER_BIND_IP"}]}
+      {listener, [{port, $RABBITMQ_MANAGER_PORT_NUMBER}, {ip, "$RABBITMQ_MANAGER_BIND_IP"}]},
+      {strict_transport_security, "max-age=0;"}
     ]
   }
 ].

--- a/3.8/ol-7/rootfs/librabbitmq.sh
+++ b/3.8/ol-7/rootfs/librabbitmq.sh
@@ -185,7 +185,8 @@ EOF
   },
   {rabbitmq_management,
     [
-      {listener, [{port, $RABBITMQ_MANAGER_PORT_NUMBER}, {ip, "$RABBITMQ_MANAGER_BIND_IP"}]}
+      {listener, [{port, $RABBITMQ_MANAGER_PORT_NUMBER}, {ip, "$RABBITMQ_MANAGER_BIND_IP"}]},
+      {strict_transport_security, "max-age=0;"}
     ]
   }
 ].


### PR DESCRIPTION
**Description of the change**

If you use Google Chrome to access your management interface through a CNAME (non-localhost) (eg. rabbitmq.internal.mycompany.com) then Chrome will default to HTTPS unless you explicitly type in `http://...`. This causes an SSL protocol error because the management interface doesn't respond with SSL certificates, etc. Chrome remembers this URL and will not let you revert to `http://` unless you clear HSTS and your browser cache. This is a pain to manage, and confusing to new users.

**Benefits**

This change effectively prevents caching of the forced-HTTPS.

**Possible drawbacks**

Cannot think of any since this image is not compatible with SSL anyway.

**Applicable issues**

N/A

**Additional information**

Workaround for needing #106 
