### PR TITLE
Switch to "sysctl" or "ini-like" format for configuration

### DIFF
--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -235,7 +235,7 @@ rabbitmq_create_enabled_plugins_file() {
         is_boolean_yes "$RABBITMQ_ENABLE_LDAP" && plugins="${plugins}, rabbitmq_auth_backend_ldap"
     fi
     cat > "${RABBITMQ_CONF_DIR}/enabled_plugins" <<EOF
-[$plugins].
+[${plugins}].
 EOF
 }
 

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -310,11 +310,9 @@ node_is_running() {
 rabbitmq_start_bg() {
     is_rabbitmq_running && return
     info "Starting RabbitMQ in background..."
-    if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then
-        "${RABBITMQ_BIN_DIR}/rabbitmq-server" &
-    else
-        "${RABBITMQ_BIN_DIR}/rabbitmq-server" >/dev/null 2>&1 &
-    fi
+    local start_command=("$RABBITMQ_BIN_DIR/rabbitmq-server")
+    am_i_root && start_command=("gosu" "$RABBITMQ_DAEMON_USER" "${start_command[@]}")
+    debug_execute "${start_command[@]}" &
     export RABBITMQ_PID="$!"
 
     if ! retry_while "debug_execute ${RABBITMQ_BIN_DIR}/rabbitmqctl wait --pid $RABBITMQ_PID --timeout 5" 10 10; then

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -29,12 +29,13 @@ rabbitmq_env() {
 export RABBITMQ_VOLUME_DIR="/bitnami/rabbitmq"
 export RABBITMQ_BASE_DIR="/opt/bitnami/rabbitmq"
 export RABBITMQ_BIN_DIR="${RABBITMQ_BASE_DIR}/sbin"
-export RABBITMQ_CONF_DIR="${RABBITMQ_BASE_DIR}/etc/rabbitmq"
 export RABBITMQ_DATA_DIR="${RABBITMQ_VOLUME_DIR}/mnesia"
+export RABBITMQ_CONF_DIR="${RABBITMQ_BASE_DIR}/etc/rabbitmq"
 export RABBITMQ_HOME_DIR="${RABBITMQ_BASE_DIR}/.rabbitmq"
 export RABBITMQ_LIB_DIR="${RABBITMQ_BASE_DIR}/var/lib/rabbitmq"
 export RABBITMQ_LOG_DIR="${RABBITMQ_BASE_DIR}/var/log/rabbitmq"
 export RABBITMQ_PLUGINS_DIR="${RABBITMQ_BASE_DIR}/plugins"
+export RABBITMQ_MOUNTED_CONF_DIR="${RABBITMQ_MOUNTED_CONF_DIR:-${RABBITMQ_VOLUME_DIR}/conf}"
 export PATH="${RABBITMQ_BIN_DIR}:${PATH}"
 
 # OS
@@ -47,7 +48,7 @@ export RABBITMQ_MNESIA_BASE="${RABBITMQ_DATA_DIR}"
 # Settings
 export RABBITMQ_CLUSTER_NODE_NAME="${RABBITMQ_CLUSTER_NODE_NAME:-}"
 export RABBITMQ_CLUSTER_PARTITION_HANDLING="${RABBITMQ_CLUSTER_PARTITION_HANDLING:-ignore}"
-export RABBITMQ_DISK_FREE_LIMIT="${RABBITMQ_DISK_FREE_LIMIT:-{mem_relative, 1.0\}}"
+export RABBITMQ_DISK_FREE_LIMIT="${RABBITMQ_DISK_FREE_LIMIT:-1.0}"
 export RABBITMQ_ERL_COOKIE="${RABBITMQ_ERL_COOKIE:-}"
 export RABBITMQ_HASHED_PASSWORD="${RABBITMQ_HASHED_PASSWORD:-}"
 export RABBITMQ_MANAGER_BIND_IP="${RABBITMQ_MANAGER_BIND_IP:-0.0.0.0}"
@@ -58,8 +59,11 @@ export RABBITMQ_NODE_TYPE="${RABBITMQ_NODE_TYPE:-stats}"
 export RABBITMQ_PASSWORD="${RABBITMQ_PASSWORD:-bitnami}"
 export RABBITMQ_USERNAME="${RABBITMQ_USERNAME:-user}"
 export RABBITMQ_VHOST="${RABBITMQ_VHOST:-/}"
+# Force boot cluster
+export RABBITMQ_FORCE_BOOT="${RABBITMQ_FORCE_BOOT:-no}"
 # Print all log messages to standard output
 export RABBITMQ_LOGS="${RABBITMQ_LOGS:--}"
+# LDAP
 export RABBITMQ_ENABLE_LDAP="${RABBITMQ_ENABLE_LDAP:-no}"
 export RABBITMQ_LDAP_TLS="${RABBITMQ_LDAP_TLS:-no}"
 export RABBITMQ_LDAP_SERVER="${RABBITMQ_LDAP_SERVER:-}"
@@ -128,7 +132,7 @@ rabbitmq_validate() {
         print_validation_error "${RABBITMQ_NODE_TYPE} is not a valid type. You can use 'stats', 'queue-disc' or 'queue-ram'."
     fi
 
-    [[ "$error_code" -eq 0 ]] || exit "$error_code"
+    [[ "$error_code" -eq 0 ]] || return "$error_code"
 }
 
 ########################
@@ -142,53 +146,52 @@ rabbitmq_validate() {
 #########################
 rabbitmq_create_config_file() {
     debug "Creating configuration file..."
-    local auth_backend=""
-    local separator=""
 
-    is_boolean_yes "$RABBITMQ_ENABLE_LDAP" && auth_backend="{auth_backends, [rabbit_auth_backend_ldap]},"
-    is_boolean_yes "$RABBITMQ_LDAP_TLS" && separator=","
+    cat > "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF
+## Networking
+listeners.tcp.default = $RABBITMQ_NODE_PORT_NUMBER
 
-    cat > "${RABBITMQ_CONF_DIR}/rabbitmq.config" <<EOF
-[
-  {rabbit,
-    [
-      $auth_backend
-      {tcp_listeners, [$RABBITMQ_NODE_PORT_NUMBER]},
-      {disk_free_limit, $RABBITMQ_DISK_FREE_LIMIT},
-      {cluster_partition_handling, $RABBITMQ_CLUSTER_PARTITION_HANDLING},
-      {default_vhost, <<"$RABBITMQ_VHOST">>},
-      {default_user, <<"$RABBITMQ_USERNAME">>},
-      {default_permissions, [<<".*">>, <<".*">>, <<".*">>]}
+## On first start RabbitMQ will create a vhost and a user. These
+## config items control what gets created
+default_vhost = $RABBITMQ_VHOST
+default_user = $RABBITMQ_USERNAME
+default_permissions.configure = .*
+default_permissions.read = .*
+default_permissions.write = .*
+
+## Clustering
+cluster_partition_handling = $RABBITMQ_CLUSTER_PARTITION_HANDLING
+
+## Set a limit relative to total available RAM
+disk_free_limit.relative = $RABBITMQ_DISK_FREE_LIMIT
+
 EOF
 
     if is_boolean_yes "$RABBITMQ_ENABLE_LDAP"; then
-        cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.config" <<EOF
-    ]
-  },
-  {rabbitmq_auth_backend_ldap,
-    [
-     {servers,               ["$RABBITMQ_LDAP_SERVER"]},
-     {user_dn_pattern,       "$RABBITMQ_LDAP_USER_DN_PATTERN"},
-     {port,                  $RABBITMQ_LDAP_SERVER_PORT}$separator
+        cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF
+## Select an authentication/authorisation backend to use
+auth_backends.1 = rabbit_auth_backend_ldap
+auth_backends.2 = internal
+
+## Connecting to the LDAP server(s)
+auth_ldap.servers.1 = $RABBITMQ_LDAP_SERVER
+auth_ldap.port = $RABBITMQ_LDAP_SERVER_PORT
+auth_ldap.user_dn_pattern = $RABBITMQ_LDAP_USER_DN_PATTERN
+
 EOF
 
         if is_boolean_yes "$RABBITMQ_LDAP_TLS"; then
-            cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.config" <<EOF
-     {use_ssl,               true}
+            cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF
+auth_ldap.use_ssl = true
+
 EOF
         fi
     fi
 
-    cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.config" <<EOF
-    ]
-  },
-  {rabbitmq_management,
-    [
-      {listener, [{port, $RABBITMQ_MANAGER_PORT_NUMBER}, {ip, "$RABBITMQ_MANAGER_BIND_IP"}]},
-      {strict_transport_security, "max-age=0;"}
-    ]
-  }
-].
+    cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF
+## Management
+management.tcp.port = $RABBITMQ_MANAGER_PORT_NUMBER
+management.tcp.ip = $RABBITMQ_MANAGER_BIND_IP
 EOF
 }
 
@@ -211,6 +214,32 @@ EOF
 }
 
 ########################
+# Creates RabbitMQ environment file
+# Globals:
+#   RABBITMQ_CONF_DIR
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+rabbitmq_create_enabled_plugins_file() {
+    debug "Creating enabled_plugins file..."
+    local plugins="rabbitmq_management_agent"
+
+    if [[ -n "${RABBITMQ_PLUGINS:-}" ]]; then
+        plugins="$RABBITMQ_PLUGINS"
+    else
+        if [[ "$RABBITMQ_NODE_TYPE" = "stats" ]]; then
+            plugins="rabbitmq_management"
+        fi
+        is_boolean_yes "$RABBITMQ_ENABLE_LDAP" && plugins="${plugins}, rabbitmq_auth_backend_ldap"
+    fi
+    cat > "${RABBITMQ_CONF_DIR}/enabled_plugins" <<EOF
+[$plugins].
+EOF
+}
+
+########################
 # Creates RabbitMQ Erlang cookie
 # Globals:
 #   RABBITMQ_ERL_COOKIE
@@ -229,25 +258,6 @@ rabbitmq_create_erlang_cookie() {
     fi
 
     echo "$RABBITMQ_ERL_COOKIE" > "${RABBITMQ_HOME_DIR}/.erlang.cookie"
-}
-
-########################
-# Enables a RabbitMQ plugin
-# Globals:
-#   RABBITMQ_BIN_DIR
-#   BITNAMI_DEBUG
-# Arguments:
-#   $1 - Plugin to enable
-# Returns:
-#   None
-#########################
-rabbitmq_enable_plugin() {
-    local plugin="${1:?plugin is required}"
-    debug "Enabling plugin '${plugin}'..."
-
-    if ! debug_execute "${RABBITMQ_BIN_DIR}/rabbitmq-plugins" "enable" "--offline" "$plugin"; then
-        warn "Couldn't enable plugin '${plugin}'."
-    fi
 }
 
 ########################
@@ -307,16 +317,10 @@ rabbitmq_start_bg() {
     fi
     export RABBITMQ_PID="$!"
 
-    local counter=0
-    while ! "${RABBITMQ_BIN_DIR}/rabbitmqctl" wait --pid "$RABBITMQ_PID" --timeout 5; do
-        debug "Waiting for RabbitMQ to start..."
-        counter=$((counter + 1))
-
-        if [[ $counter -eq 10 ]]; then
-            error "Couldn't start RabbitMQ in background."
-            exit 1
-        fi
-    done
+    if ! retry_while "debug_execute ${RABBITMQ_BIN_DIR}/rabbitmqctl wait --pid $RABBITMQ_PID --timeout 5" 10 10; then
+        error "Couldn't start RabbitMQ in background."
+        return 1
+    fi
 }
 
 ########################
@@ -334,13 +338,9 @@ rabbitmq_stop() {
     info "Stopping RabbitMQ..."
 
     debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" stop
-
-    local counter=10
-    while [[ "$counter" -ne 0 ]] && is_rabbitmq_running; do
-        debug "Waiting for RabbitMQ to stop..."
-        sleep 1
-        counter=$((counter - 1))
-    done
+    retry_while "is_rabbitmq_running" 10 1
+    # We give two extra seconds for halting Erlang VM
+    sleep 2
 }
 
 ########################
@@ -361,32 +361,7 @@ rabbitmq_change_password() {
 
     if ! debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" change_password "$user" "$password"; then
         error "Couldn't change password for user '${user}'."
-        exit 1
-    fi
-}
-
-########################
-# Migrate old custom configuration files
-# Globals:
-#   RABBITMQ_CONF_DIR
-#   RABBITMQ_VOLUME_DIR
-# Arguments:
-#   None
-# Returns:
-#   None
-#########################
-migrate_old_configuration() {
-    debug "Persisted configuration detected. Migrating any existing configuration files..."
-    warn "Configuration files won't be persisted anymore!"
-
-    cp -Lr "${RABBITMQ_VOLUME_DIR}/conf/." "$RABBITMQ_CONF_DIR"
-    cp -Lr "${RABBITMQ_VOLUME_DIR}/var/lib/rabbitmq/mnesia" "$RABBITMQ_VOLUME_DIR"
-
-    if am_i_root; then
-        [[ -e "${RABBITMQ_VOLUME_DIR}/.initialized" ]] && rm "${RABBITMQ_VOLUME_DIR}/.initialized"
-        rm -rf "${RABBITMQ_VOLUME_DIR}/conf" "${RABBITMQ_VOLUME_DIR:?}/var" "${RABBITMQ_VOLUME_DIR}/.rabbitmq"
-    else
-        warn "Old configuration migrated, please manually remove the 'conf', 'var' and '.rabbitmq' directories from the volume."
+        return 1
     fi
 }
 
@@ -411,20 +386,15 @@ rabbitmq_join_cluster() {
     debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" stop_app
 
     local counter=0
-    while ! debug_execute "${RABBITMQ_BIN_DIR}/rabbitmq-plugins" --node "$clusternode" is_enabled rabbitmq_management; do
-        debug "Waiting for ${clusternode} to be ready..."
-        counter=$((counter + 1))
-        sleep 1
-        if [[ $counter -eq 120 ]]; then
-            error "Node ${clusternode} is not running."
-            exit 1
-        fi
-    done
+    if ! retry_while "debug_execute ${RABBITMQ_BIN_DIR}/rabbitmq-plugins --node $clusternode is_enabled rabbitmq_management" 120 1; then
+        error "Node ${clusternode} is not running."
+        return 1
+    fi
 
     info "Clustering with ${clusternode}"
     if ! debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" join_cluster "${join_cluster_args[@]}"; then
         error "Couldn't cluster with node '${clusternode}'."
-        exit 1
+        return 1
     fi
 
     debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" start_app
@@ -441,44 +411,42 @@ rabbitmq_join_cluster() {
 #########################
 rabbitmq_initialize() {
     info "Initializing RabbitMQ..."
-    local skip_setup=false
 
-    ! is_dir_empty "$RABBITMQ_DATA_DIR" && skip_setup=true
-
-    # Persisted configuration files from old versions
-    ! is_dir_empty "$RABBITMQ_VOLUME_DIR" && [[ -d "${RABBITMQ_VOLUME_DIR}/conf" ]] && migrate_old_configuration && skip_setup=true
-
-    [[ ! -f "${RABBITMQ_CONF_DIR}/rabbitmq.config" ]] && rabbitmq_create_config_file
+    # Check for mounted configuration files
+    if ! is_dir_empty "$RABBITMQ_MOUNTED_CONF_DIR"; then
+        cp -Lr "$RABBITMQ_MOUNTED_CONF_DIR"/* "$RABBITMQ_CONF_DIR"
+    fi
+    [[ ! -f "${RABBITMQ_CONF_DIR}/rabbitmq.conf" ]] && rabbitmq_create_config_file
     [[ ! -f "${RABBITMQ_CONF_DIR}/rabbit-env.conf" ]] && rabbitmq_create_environment_file
+    [[ ! -f "${RABBITMQ_CONF_DIR}/enabled_plugins" ]] && rabbitmq_create_enabled_plugins_file
 
+    [[ ! -f "${RABBITMQ_LIB_DIR}/.start" ]] && touch "${RABBITMQ_LIB_DIR}/.start"
     [[ ! -f "${RABBITMQ_HOME_DIR}/.erlang.cookie" ]] && rabbitmq_create_erlang_cookie
     chmod 400 "${RABBITMQ_HOME_DIR}/.erlang.cookie"
     ln -sf "${RABBITMQ_HOME_DIR}/.erlang.cookie" "${RABBITMQ_LIB_DIR}/.erlang.cookie"
+
+    # Resources limits: maximum number of open file descriptors
+    [[ -n "${RABBITMQ_ULIMIT_NOFILES:-}" ]] && ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"
 
     debug "Ensuring expected directories/files exist..."
     for dir in "$RABBITMQ_DATA_DIR" "$RABBITMQ_LIB_DIR" "$RABBITMQ_HOME_DIR"; do
         ensure_dir_exists "$dir"
         am_i_root && chown -R "$RABBITMQ_DAEMON_USER:$RABBITMQ_DAEMON_GROUP" "$dir"
     done
-    if "$skip_setup"; then
+
+    if ! find "$RABBITMQ_DATA_DIR" -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" -exec false {} +; then
         info "Persisted data detected. Restoring..."
+        if is_boolean_yes "$RABBITMQ_FORCE_BOOT" && ! is_dir_empty "${RABBITMQ_DATA_DIR}/${RABBITMQ_NODE_NAME}"; then
+            # ref: https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot
+            warm "Forcing node to start..."
+            debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" force_boot
+        fi
     else
         ! is_rabbitmq_running && rabbitmq_start_bg
 
         rabbitmq_change_password "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
-
         if [[ "$RABBITMQ_NODE_TYPE" != "stats" ]] && [[ -n "$RABBITMQ_CLUSTER_NODE_NAME" ]]; then
             rabbitmq_join_cluster "$RABBITMQ_CLUSTER_NODE_NAME" "$RABBITMQ_NODE_TYPE"
         fi
-    fi
-
-    if [[ "$RABBITMQ_NODE_TYPE" = "stats" ]]; then
-        rabbitmq_enable_plugin "rabbitmq_management"
-    else
-        rabbitmq_enable_plugin "rabbitmq_management_agent"
-    fi
-
-    if is_boolean_yes "$RABBITMQ_ENABLE_LDAP"; then
-        rabbitmq_enable_plugin "rabbitmq_auth_backend_ldap"
     fi
 }

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/apicheck.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/apicheck.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace
+
+# Load libraries
+. /opt/bitnami/scripts/libos.sh
+
+URL=$1
+EXPECTED=$2
+ACTUAL=$(curl --silent --show-error --fail "$URL")
+info "Actual response: $ACTUAL"
+info "Expected response: $EXPECTED"
+test "$EXPECTED" = "$ACTUAL"

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/apicheck.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/apicheck.sh
@@ -13,6 +13,6 @@ set -o pipefail
 URL=$1
 EXPECTED=$2
 ACTUAL=$(curl --silent --show-error --fail "$URL")
-info "Actual response: $ACTUAL"
-info "Expected response: $EXPECTED"
+info "Actual response: ${ACTUAL}"
+info "Expected response: ${EXPECTED}"
 test "$EXPECTED" = "$ACTUAL"

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/healthcheck.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/healthcheck.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace
+
+# Load libraries
+. /opt/bitnami/scripts/librabbitmq.sh
+
+# Load RabbitMQ environment variables
+eval "$(rabbitmq_env)"
+
+if [[ -f "${RABBITMQ_LIB_DIR}/.start" ]]; then
+    rabbitmqctl node_health_check
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        rabbitmqctl status
+        exit $?
+    fi
+    rm -f "${RABBITMQ_LIB_DIR}/.start"
+    exit ${RESULT}
+fi
+
+/opt/bitnami/scripts/rabbitmq/apicheck.sh $1 $2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# What is RabbitMQ?
+# Bitnami Docker Image for RabbitMQ
+
+## What is RabbitMQ?
 
 > RabbitMQ is an open source message broker software that implements the Advanced Message Queuing Protocol (AMQP).
 > The RabbitMQ server is written in the Erlang programming language and is built on the Open Telecom Platform
@@ -7,20 +9,20 @@
 
 [https://www.rabbitmq.com/](https://www.rabbitmq.com/)
 
-# TL;DR;
+## TL;DR;
 
 ```console
 $ docker run --name rabbitmq bitnami/rabbitmq:latest
 ```
 
-## Docker Compose
+### Docker Compose
 
 ```console
 $ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-rabbitmq/master/docker-compose.yml > docker-compose.yml
 $ docker-compose up -d
 ```
 
-# Why use Bitnami Images?
+## Why use Bitnami Images?
 
 * Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.
 * With Bitnami images the latest bug fixes and features are available as soon as possible.
@@ -32,26 +34,25 @@ $ docker-compose up -d
 
 > This [CVE scan report](https://quay.io/repository/bitnami/rabbitmq?tab=tags) contains a security report with all open CVEs. To get the list of actionable security issues, find the "latest" tag, click the vulnerability report link under the corresponding "Security scan" field and then select the "Only show fixable" filter on the next page.
 
-# How to deploy RabbitMQ in Kubernetes?
+## How to deploy RabbitMQ in Kubernetes?
 
 Deploying Bitnami applications as Helm Charts is the easiest way to get started with our applications on Kubernetes. Read more about the installation in the [Bitnami RabbitMQ Chart GitHub repository](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq).
 
 Bitnami containers can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
 
-# Why use a non-root container?
+## Why use a non-root container?
 
 Non-root container images add an extra layer of security and are generally recommended for production environments. However, because they run as a non-root user, privileged tasks are typically off-limits. Learn more about non-root containers [in our docs](https://docs.bitnami.com/tutorials/work-with-non-root-containers/).
 
-# Supported tags and respective `Dockerfile` links
+## Supported tags and respective `Dockerfile` links
 
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
-
 
 * [`3.8-debian-10`, `3.8.3-debian-10-r103`, `3.8`, `3.8.3`, `latest` (3.8/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-rabbitmq/blob/3.8.3-debian-10-r103/3.8/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/rabbitmq GitHub repo](https://github.com/bitnami/bitnami-docker-rabbitmq).
 
-# Get this image
+## Get this image
 
 The recommended way to get the Bitnami RabbitMQ Docker Image is to pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/bitnami/rabbitmq).
 
@@ -71,7 +72,7 @@ If you wish, you can also build the image yourself.
 $ docker build -t bitnami/rabbitmq:latest 'https://github.com/bitnami/bitnami-docker-rabbitmq.git#master:3.8/debian-10'
 ```
 
-# Persisting your application
+## Persisting your application
 
 If you remove the container all your data will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
@@ -95,23 +96,23 @@ rabbitmq:
 
 > NOTE: As this is a non-root container, the mounted files and directories must have the proper permissions for the UID `1001`.
 
-# Connecting to other containers
+## Connecting to other containers
 
 Using [Docker container networking](https://docs.docker.com/engine/userguide/networking/), a RabbitMQ server running inside a container can easily be accessed by your application containers.
 
 Containers attached to the same network can communicate with each other using the container name as the hostname.
 
-## Using the Command Line
+### Using the Command Line
 
 In this example, we will create a RabbitMQ client instance that will connect to the server instance that is running on the same docker network as the client.
 
-### Step 1: Create a network
+#### Step 1: Create a network
 
 ```console
 $ docker network create app-tier --driver bridge
 ```
 
-### Step 2: Launch the RabbitMQ server instance
+#### Step 2: Launch the RabbitMQ server instance
 
 Use the `--network app-tier` argument to the `docker run` command to attach the RabbitMQ container to the `app-tier` network.
 
@@ -121,7 +122,7 @@ $ docker run -d --name rabbitmq-server \
     bitnami/rabbitmq:latest
 ```
 
-### Step 3: Launch your RabbitMQ client instance
+#### Step 3: Launch your RabbitMQ client instance
 
 Finally we create a new container instance to launch the RabbitMQ client and connect to the server created in the previous step:
 
@@ -131,7 +132,7 @@ $ docker run -it --rm \
     bitnami/rabbitmq:latest rabbitmqctl -n rabbit@rabbitmq-server status
 ```
 
-## Using Docker Compose
+### Using Docker Compose
 
 When not specified, Docker Compose automatically sets up a new network and attaches all deployed services to that network. However, we will explicitly define a new `bridge` network named `app-tier`. In this example we assume that you want to connect to the RabbitMQ server from your own custom application image which is identified in the following snippet by the service name `myapp`.
 
@@ -164,9 +165,9 @@ Launch the containers using:
 $ docker-compose up -d
 ```
 
-# Configuration
+## Configuration
 
-## Environment variables
+### Environment variables
 
  When you start the rabbitmq image, you can adjust the configuration of the instance by passing one or more environment variables either on the docker-compose file or on the `docker run` command line. If you want to add a new environment variable:
 
@@ -180,36 +181,38 @@ rabbitmq:
   ...
 ```
 
- * For manual execution add a `-e` option with each variable and value.
+* For manual execution add a `-e` option with each variable and value.
 
 Available variables:
 
- - `RABBITMQ_USERNAME`: RabbitMQ application username. Default: **user**
- - `RABBITMQ_PASSWORD`: RabbitMQ application password. Default: **bitnami**
- - `RABBITMQ_HASHED_PASSWORD`: RabbitMQ application hashed password.
- - `RABBITMQ_VHOST`: RabbitMQ application vhost. Default: **/**
- - `RABBITMQ_ERL_COOKIE`: Erlang cookie to determine whether different nodes are allowed to communicate with each other.
- - `RABBITMQ_NODE_TYPE`: Node Type. Valid values: *stats*, *queue-ram* or *queue-disc*. Default: **stats**
- - `RABBITMQ_NODE_NAME`: Node name and host. E.g.: *node@hostname* or *node* (localhost won't work in cluster topology). Default **rabbit@localhost**. If using this variable, ensure that you specify a valid host name as the container wil fail to start otherwise.
- - `RABBITMQ_NODE_PORT_NUMBER`: Node port. Default: **5672**
- - `RABBITMQ_CLUSTER_NODE_NAME`: Node name to cluster with. E.g.: **clusternode@hostname**
- - `RABBITMQ_CLUSTER_PARTITION_HANDLING`: Cluster partition recovery mechanism. Default: **ignore**
- - `RABBITMQ_MANAGER_PORT_NUMBER`: Manager port. Default: **15672**
- - `RABBITMQ_DISK_FREE_LIMIT`: Disk free space limit of the partition on which RabbitMQ is storing data. Default: **{mem_relative, 1.0}**
- - `RABBITMQ_ULIMIT_NOFILES`: Resources limits: maximum number of open file descriptors. Default: **65536**
- - `RABBITMQ_ENABLE_LDAP`: Enable the LDAP configuration. Defaults to `no`.
- - `RABBITMQ_LDAP_TLS`: Enable secure LDAP configuration. Defaults to `no`.
- - `RABBITMQ_LDAP_SERVER`: Hostname of the LDAP server. No defaults.
- - `RABBITMQ_LDAP_SERVER_PORT`: Port of the LDAP server. Defaults to `389`.
- - `RABBITMQ_LDAP_USER_DN_PATTERN`: DN used to bind to LDAP in the form `cn=$${username},dc=example,dc=org`. No defaults.
+* `RABBITMQ_USERNAME`: RabbitMQ application username. Default: **user**
+* `RABBITMQ_PASSWORD`: RabbitMQ application password. Default: **bitnami**
+* `RABBITMQ_HASHED_PASSWORD`: RabbitMQ application hashed password.
+* `RABBITMQ_VHOST`: RabbitMQ application vhost. Default: **/**
+* `RABBITMQ_ERL_COOKIE`: Erlang cookie to determine whether different nodes are allowed to communicate with each other.
+* `RABBITMQ_NODE_TYPE`: Node Type. Valid values: *stats*, *queue-ram* or *queue-disc*. Default: **stats**
+* `RABBITMQ_NODE_NAME`: Node name and host. E.g.: *node@hostname* or *node* (localhost won't work in cluster topology). Default **rabbit@localhost**. If using this variable, ensure that you specify a valid host name as the container wil fail to start otherwise.
+* `RABBITMQ_FORCE_BOOT`: Force a node to start even if it was not the last to shut down. Default: **no**
+* `RABBITMQ_NODE_PORT_NUMBER`: Node port. Default: **5672**
+* `RABBITMQ_CLUSTER_NODE_NAME`: Node name to cluster with. E.g.: **clusternode@hostname**
+* `RABBITMQ_CLUSTER_PARTITION_HANDLING`: Cluster partition recovery mechanism. Default: **ignore**
+* `RABBITMQ_MANAGER_PORT_NUMBER`: Manager port. Default: **15672**
+* `RABBITMQ_DISK_FREE_LIMIT`: Disk free space limit of the partition on which RabbitMQ is storing data. Default: **{mem_relative, 1.0}**
+* `RABBITMQ_ULIMIT_NOFILES`: Resources limits: maximum number of open file descriptors. Default: **65536**
+* `RABBITMQ_ENABLE_LDAP`: Enable the LDAP configuration. Defaults: **no**
+* `RABBITMQ_LDAP_TLS`: Enable secure LDAP configuration. Defaults: **no**
+* `RABBITMQ_LDAP_SERVER`: Hostname of the LDAP server. No defaults.
+* `RABBITMQ_LDAP_SERVER_PORT`: Port of the LDAP server. Defaults: **389**
+* `RABBITMQ_LDAP_USER_DN_PATTERN`: DN used to bind to LDAP in the form `cn=$${username},dc=example,dc=org`. No defaults.
+* `RABBITMQ_PLUGINS`: Comma, semi-colon or space separated list of plugins to enable during the initialization. No defaults.
 
-## Setting up a cluster
+### Setting up a cluster
 
-### Docker Compose
+#### Docker Compose
 
 This is the simplest way to run RabbitMQ with clustering configuration:
 
-#### Step 1: Add a stats node in your `docker-compose.yml`
+##### Step 1: Add a stats node in your `docker-compose.yml`
 
 Copy the snippet below into your docker-compose.yml to add a RabbitMQ stats node to your cluster configuration.
 
@@ -231,7 +234,7 @@ services:
 
 > **Note:** The name of the service (**stats**) is important so that a node could resolve the hostname to cluster with. (Note that the node name is `rabbit@stats`)
 
-#### Step 2: Add a queue node in your configuration
+##### Step 2: Add a queue node in your configuration
 
 Update the definitions for nodes you want your RabbitMQ stats node cluster with.
 
@@ -263,7 +266,7 @@ We are going to add a ram node too:
       - 'rabbitmqram1_data:/bitnami'
 ```
 
-#### Step 3: Add the volume description
+##### Step 3: Add the volume description
 
 ```yaml
 volumes:
@@ -319,23 +322,23 @@ volumes:
     driver: local
 ```
 
-## Configuration file
+### Configuration file
 
 A custom configuration file can be mounted to the `/opt/bitnami/rabbitmq/etc/rabbitmq` directory. If no file is mounted, the container will generate one.
 
-## Enabling LDAP support
+### Enabling LDAP support
 
 LDAP configuration parameters must be specified if you wish to enable LDAP support. The following environment variables are available to configure LDAP support:
 
- - `RABBITMQ_ENABLE_LDAP`: Enable the LDAP configuration. Defaults to `no`.
- - `RABBITMQ_LDAP_TLS`: Enable secure LDAP configuration. Defaults to `no`.
- - `RABBITMQ_LDAP_SERVER`: Hostname of the LDAP server. No defaults.
- - `RABBITMQ_LDAP_SERVER_PORT`: Port of the LDAP server. Defaults to `389`.
- - `RABBITMQ_LDAP_USER_DN_PATTERN`: DN used to bind to LDAP in the form `cn=$${username},dc=example,dc=org`.No defaults.
+* `RABBITMQ_ENABLE_LDAP`: Enable the LDAP configuration. Defaults to `no`.
+* `RABBITMQ_LDAP_TLS`: Enable secure LDAP configuration. Defaults to `no`.
+* `RABBITMQ_LDAP_SERVER`: Hostname of the LDAP server. No defaults.
+* `RABBITMQ_LDAP_SERVER_PORT`: Port of the LDAP server. Defaults to `389`.
+* `RABBITMQ_LDAP_USER_DN_PATTERN`: DN used to bind to LDAP in the form `cn=$${username},dc=example,dc=org`.No defaults.
 
 > Note: To escape `$` in `RABBITMQ_LDAP_USER_DN_PATTERN` you need to use `$$`.
 
-# Logging
+## Logging
 
 The Bitnami RabbitMQ Docker image sends the container logs to the `stdout`. To view the logs:
 
@@ -351,13 +354,13 @@ $ docker-compose logs rabbitmq
 
 You can configure the containers [logging driver](https://docs.docker.com/engine/admin/logging/overview/) using the `--log-driver` option if you wish to consume the container logs differently. In the default configuration docker uses the `json-file` driver.
 
-# Maintenance
+## Maintenance
 
-## Upgrade this application
+### Upgrade this application
 
 Bitnami provides up-to-date versions of RabbitMQ, including security patches, soon after they are made upstream. We recommend that you follow these steps to upgrade your container.
 
-### Step 1: Get the updated image
+#### Step 1: Get the updated image
 
 ```console
 $ docker pull bitnami/rabbitmq:latest
@@ -366,7 +369,7 @@ $ docker pull bitnami/rabbitmq:latest
 or if you're using Docker Compose, update the value of the image property to
 `bitnami/rabbitmq:latest`.
 
-### Step 2: Stop and backup the currently running container
+#### Step 2: Stop and backup the currently running container
 
 Stop the currently running container using the command
 
@@ -386,7 +389,7 @@ Next, take a snapshot of the persistent volume `/path/to/rabbitmq-persistence` u
 $ rsync -a /path/to/rabbitmq-persistence /path/to/rabbitmq-persistence.bkp.$(date +%Y%m%d-%H.%M.%S)
 ```
 
-### Step 3: Remove the currently running container
+#### Step 3: Remove the currently running container
 
 ```console
 $ docker rm -v rabbitmq
@@ -398,7 +401,7 @@ or using Docker Compose:
 $ docker-compose rm -v rabbitmq
 ```
 
-### Step 4: Run the new image
+#### Step 4: Run the new image
 
 Re-create your container from the new image.
 
@@ -412,66 +415,67 @@ or using Docker Compose:
 $ docker-compose up rabbitmq
 ```
 
-# Notable changes
+## Notable changes
 
-## 3.8.0-r17, 3.8.0-ol-7-r26
+### 3.8.3-debian-10-r104
 
-- LDAP authentication
+* The default configuration file is created following the "sysctl" or "ini-like" format instead of using Erlang terms. Check [Official documentation](https://www.rabbitmq.com/configure.html#config-file-formats) for more information about supported formats.
+* Migrating data/configuration from unsupported locations is not performed anymore.
+* New environment variable `RABBITMQ_FORCE_BOOT` to force a node to start even if it was not the last to shut down.
+* New environment variable `RABBITMQ_PLUGINS` to indicate a list of plugins to enable during the initialization.
+* Add healthcheck scripts to be used on K8s environments.
 
-## 3.7.15-r18, 3.7.15-ol-7-r19
-- Decrease the size of the container. Node.js is not needed anymore. RabbitMQ configuration logic has been moved to bash scripts in the `rootfs` folder.
-- Configuration is not persisted anymore.
+### 3.8.0-r17, 3.8.0-ol-7-r26
 
-## 3.7.7-r35
+* LDAP authentication
 
-- The RabbitMQ container includes a new environment variable `RABBITMQ_HASHED_PASSWORD` that allows setting password via SHA256 hash (consult [official documentation](https://www.rabbitmq.com/passwords.html) for more information about password hashes).
-- Please note that password hashes must be generated following the [official algorithm](https://www.rabbitmq.com/passwords.html#computing-password-hash). You can use [this Python script](https://gist.githubusercontent.com/anapsix/4c3e8a8685ce5a3f0d7599c9902fd0d5/raw/1203a480fcec1982084b3528415c3cad26541b82/rmq_passwd_hash.py) to generate them.
+### 3.7.15-r18, 3.7.15-ol-7-r19
 
-## 3.7.7-r19
+* Decrease the size of the container. Node.js is not needed anymore. RabbitMQ configuration logic has been moved to bash scripts in the `rootfs` folder.
+* Configuration is not persisted anymore.
 
-- The RabbitMQ container has been migrated to a non-root user approach. Previously the container ran as the `root` user and the RabbitMQ daemon was started as the `rabbitmq` user. From now on, both the container and the RabbitMQ daemon run as user `1001`. As a consequence, the data directory must be writable by that user. You can revert this behavior by changing `USER 1001` to `USER root` in the Dockerfile.
+### 3.7.7-r35
 
-## 3.6.5-r2
+* The RabbitMQ container includes a new environment variable `RABBITMQ_HASHED_PASSWORD` that allows setting password via SHA256 hash (consult [official documentation](https://www.rabbitmq.com/passwords.html) for more information about password hashes).
+* Please note that password hashes must be generated following the [official algorithm](https://www.rabbitmq.com/passwords.html#computing-password-hash). You can use [this Python script](https://gist.githubusercontent.com/anapsix/4c3e8a8685ce5a3f0d7599c9902fd0d5/raw/1203a480fcec1982084b3528415c3cad26541b82/rmq_passwd_hash.py) to generate them.
+
+### 3.7.7-r19
+
+* The RabbitMQ container has been migrated to a non-root user approach. Previously the container ran as the `root` user and the RabbitMQ daemon was started as the `rabbitmq` user. From now on, both the container and the RabbitMQ daemon run as user `1001`. As a consequence, the data directory must be writable by that user. You can revert this behavior by changing `USER 1001` to `USER root` in the Dockerfile.
+
+### 3.6.5-r2
 
 The following parameters have been renamed:
 
 |            From            |              To              |
 |----------------------------|------------------------------|
-| `RABBITMQ_ERLANG_COOKIE`    | `RABBITMQ_ERL_COOKIE`     |
-
-## 3.6.5-r2
-
-The following parameters have been renamed:
-
-|            From            |              To              |
-|----------------------------|------------------------------|
-| `RABBITMQ_ERLANGCOOKIE`    | `RABBITMQ_ERLANG_COOKIE`     |
+| `RABBITMQ_ERLANG_COOKIE`   | `RABBITMQ_ERL_COOKIE`        |
 | `RABBITMQ_NODETYPE`        | `RABBITMQ_NODE_TYPE`         |
 | `RABBITMQ_NODEPORT`        | `RABBITMQ_NODE_PORT`         |
 | `RABBITMQ_NODENAME`        | `RABBITMQ_NODE_NAME`         |
 | `RABBITMQ_CLUSTERNODENAME` | `RABBITMQ_CLUSTER_NODE_NAME` |
 | `RABBITMQ_MANAGERPORT`     | `RABBITMQ_MANAGER_PORT`      |
 
-# Contributing
+## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an
 [issue](https://github.com/bitnami/bitnami-docker-rabbitmq/issues), or submit a
 [pull request](https://github.com/bitnami/bitnami-docker-rabbitmq/pulls) with your contribution.
 
-# Issues
+## Issues
 
 If you encountered a problem running this container, you can file an
 [issue](https://github.com/bitnami/bitnami-docker-rabbitmq/issues/new). For us to provide better support,
 be sure to include the following information in your issue:
 
-- Host OS and version
-- Docker version (`docker version`)
-- Output of `docker info`
-- Version of this container (`echo $BITNAMI_IMAGE_VERSION` inside the container)
-- The command you used to run the container, and any relevant output you saw (masking any sensitive
+* Host OS and version
+* Docker version (`docker version`)
+* Output of `docker info`
+* Version of this container (`echo $BITNAMI_IMAGE_VERSION` inside the container)
+* The command you used to run the container, and any relevant output you saw (masking any sensitive
 information)
 
-# License
+## License
 
 Copyright (c) 2020 Bitnami
 


### PR DESCRIPTION
**Description of the change**

This PR switches the format used to generate default configuration file so it uses the "sysctl" or "ini-like" format instead of using Erlang terms. Check [Official documentation](https://www.rabbitmq.com/configure.html#config-file-formats) for more information about supported formats.

Apart from that, this PR also:

* Removes support to migrate data/configuration from unsupported locations.
* Add a new environment variable `RABBITMQ_FORCE_BOOT` to force a node to start even if it was not the last to shut down.
* Add a new environment variable `RABBITMQ_PLUGINS` to indicate a list of plugins to enable during the initialization.
* Add healthcheck scripts to be used on K8s environments.

**Benefits**

Use recommended configuration format, and extend image capabilities.

**Possible drawbacks**

None
