### PR TITLE
Support for ad-hoc custom configuration.

### DIFF
--- a/3.8/debian-10/Dockerfile
+++ b/3.8/debian-10/Dockerfile
@@ -10,6 +10,7 @@ ENV HOME="/opt/bitnami/rabbitmq/.rabbitmq" \
 COPY prebuildfs /
 # Install required system packages and dependencies
 RUN install_packages ca-certificates curl gzip libc6 libssl1.1 libtinfo6 locales procps tar zlib1g
+RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "ini-file" "1.3.0-0" --checksum 41c77c119c1fb01936942bdd7f463f777d5edc29809038f977a7ab78ffdab342
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "erlang" "22.3.0-0" --checksum e9b6cba6a355dc2a6cc59829a59240d70cfb247f584a5f65f16fd6754c716166
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "rabbitmq" "3.8.5-0" --checksum 6eded4caabf8d11c7b8c316c766f122e6c67ba5a2500eb9663ad46cad471dd40
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-0" --checksum 582d501eeb6b338a24f417fededbf14295903d6be55c52d66c52e616c81bcd8c

--- a/3.8/debian-10/Dockerfile
+++ b/3.8/debian-10/Dockerfile
@@ -10,8 +10,6 @@ ENV HOME="/opt/bitnami/rabbitmq/.rabbitmq" \
 COPY prebuildfs /
 # Install required system packages and dependencies
 RUN install_packages acl ca-certificates curl gzip libc6 libssl1.1 libtinfo6 locales procps tar zlib1g
-RUN install_packages ca-certificates curl gzip libc6 libssl1.1 libtinfo6 locales procps tar zlib1g
-RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "ini-file" "1.3.0-0" --checksum 41c77c119c1fb01936942bdd7f463f777d5edc29809038f977a7ab78ffdab342
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "erlang" "22.3.0-0" --checksum e9b6cba6a355dc2a6cc59829a59240d70cfb247f584a5f65f16fd6754c716166
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "rabbitmq" "3.8.5-1" --checksum 87c9b51267adfda27bfc267f8376e84db9be48ef681bb4e2085bbc2bba96c16e
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-1" --checksum 51cfb1b7fd7b05b8abd1df0278c698103a9b1a4964bdacd87ca1d5c01631d59c

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -447,7 +447,7 @@ rabbitmq_initialize() {
     [[ ! -f "${RABBITMQ_CONF_DIR}/enabled_plugins" ]] && rabbitmq_create_enabled_plugins_file
 
     # User injected custom configuration
-    if [ -f "$RABBITMQ_CUSTOM_CONF_DIR/my_custom.conf" ]; then
+    if [[ -f "$RABBITMQ_CUSTOM_CONF_DIR/my_custom.conf" ]]; then
         debug "Injecting custom configuration from my_custom.conf"
         cat "${RABBITMQ_CUSTOM_CONF_DIR}/my_custom.conf" | while IFS='=' read -r custom_key custom_value || [[ -n $custom_key ]];
         do

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -415,11 +415,16 @@ rabbitmq_conf_set() {
     local -r value="${2:?value missing}"
     local -r file="${3:-"$RABBITMQ_CONF_FILE"}"
     info "Setting ${key} option"
-    debug "Setting ${key} to '${value}' in ${RABBITMQ_CONF_FILE} configuration"
-    # Check if the configuration exists in the file
-    ini-file set --section "" --key "$key" --value "$value" "$file"
-    sed -i 's/;//g' "$file"  # Remove semicolon produced by ini-file command
-    sed -i 's/^\s*//g' "$file"  # Remove leading spaces that occur in affect to the semicolon bug.
+    debug "Setting ${key} to '${value}' in ${file} configuration"
+
+    if grep -qE "${key}" "${file}"; then
+      # Key already exists, overide old value
+      replace_in_file "${file}" "^${key}\s*=\s*.*" "${key} = ${value}"
+    else
+      # Key does not exists. append to end of file.
+      echo "${key} = ${value}" >> "${file}"
+    fi
+
 
 }
 

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -461,11 +461,7 @@ rabbitmq_conf_set() {
       # Key does not exists. append to end of file.
       echo "${key} = ${value}" >> "${file}"
     fi
-
-
 }
-
-
 
 ########################
 # Ensure RabbitMQ is initialized

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -488,7 +488,7 @@ rabbitmq_initialize() {
     # User injected custom configuration
     if [[ -f "$RABBITMQ_CUSTOM_CONF_DIR/my_custom.conf" ]]; then
         debug "Injecting custom configuration from my_custom.conf"
-        cat "${RABBITMQ_CUSTOM_CONF_DIR}/my_custom.conf" | while IFS='=' read -r custom_key custom_value || [[ -n $custom_key ]];
+        grep -E "^\w.*\s?=\s?.*" "${RABBITMQ_CUSTOM_CONF_DIR}/my_custom.conf" | while IFS='=' read -r custom_key custom_value || [[ -n $custom_key ]];
         do
             rabbitmq_conf_set "$custom_key" "$custom_value" "${RABBITMQ_CONF_FILE}"
         done

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $ docker-compose up -d
 ```
 
 ## Configuration
-The image looks for user-defined configurations in /bitnami/conf/my_custom.conf. Create a file named my_custom.cnf and mount it at /bitnami/conf/my_custom.conf.
+The image looks for user-defined configurations in /bitnami/conf/my_custom.conf. Create a file named my_custom.conf and mount it at /bitnami/conf/my_custom.conf.
 
 For example, in order to override the `listeners.tcp.default` directive:
 
@@ -178,7 +178,7 @@ listeners.tcp.default=1337
 
 #### Step 2: Added the following volume to your configuration.
 ```
--v /path/to/my_custom.cnf:/bitnami/conf/my_custom.cnf:ro \
+-v /path/to/my_custom.conf:/bitnami/conf/my_custom.conf:ro \
 ```
 
 After that, your changes will be taken into account in the server's behaviour.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,23 @@ $ docker-compose up -d
 ```
 
 ## Configuration
+The image looks for user-defined configurations in /bitnami/conf/my_custom.conf. Create a file named my_custom.cnf and mount it at /bitnami/conf/my_custom.conf.
+
+For example, in order to override the `listeners.tcp.default` directive:
+
+#### Step 1: Write your my_custom.conf file with the following content.
+```ini
+listeners.tcp.default=1337
+```
+
+#### Step 2: Added the following volume to your configuration.
+```
+-v /path/to/my_custom.cnf:/bitnami/conf/my_custom.cnf:ro \
+```
+
+After that, your changes will be taken into account in the server's behaviour.
+
+Refer to the RabbitMQ server option and variable reference guide for the complete list of configuration options.
 
 ### Environment variables
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
The following changes apply custom configuration routines for the rabbitq image, similar to what exists in MySQL and MariaDB. The changes allows user to define a `my_custom.conf` file that is read on setup with custom configuration. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
The proposed changes will allow users to ad-hoc change specific settings of the rabbitmq.conf.
One use-case would be to set the logging configuration and leave rest default.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
I cannot see any particular drawbacks except that misconfiguration might break the application. This would in any case happen if the user misconfigures a manual forged rabbitmq.conf
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**
The only concern of current version is that I had to use sed to remove superfluous semicolons that were generated by the ini-file component. As rabbitmq has no sections (however, similar structure), and allows hashtag comments, it generates  ini-file styled comments where hashtags appear.

This is, however fixed by a simple sed.

Also I could not get:
```
 while IFS='=' read -r custom_key custom_value;
do
 # CODE
done < "${RABBITMQ_CUSTOM_CONF_DIR}/my_custom.conf";
```

 to work in the image, however, this was fixed by using `cat` instead. Im not sure of the implications of using cat instead, but it works well as far as I can tell.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
