### PR TITLE
Provide a way to set an absolute value for Disk Free Limit

### DIFF
--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -48,7 +48,8 @@ export RABBITMQ_MNESIA_BASE="${RABBITMQ_DATA_DIR}"
 # Settings
 export RABBITMQ_CLUSTER_NODE_NAME="${RABBITMQ_CLUSTER_NODE_NAME:-}"
 export RABBITMQ_CLUSTER_PARTITION_HANDLING="${RABBITMQ_CLUSTER_PARTITION_HANDLING:-ignore}"
-export RABBITMQ_DISK_FREE_LIMIT="${RABBITMQ_DISK_FREE_LIMIT:-1.0}"
+export RABBITMQ_DISK_FREE_RELATIVE_LIMIT="${RABBITMQ_DISK_FREE_RELATIVE_LIMIT:-1.0}"
+export RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT="${RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT:-}"
 export RABBITMQ_ERL_COOKIE="${RABBITMQ_ERL_COOKIE:-}"
 export RABBITMQ_HASHED_PASSWORD="${RABBITMQ_HASHED_PASSWORD:-}"
 export RABBITMQ_MANAGER_BIND_IP="${RABBITMQ_MANAGER_BIND_IP:-0.0.0.0}"
@@ -161,11 +162,19 @@ default_permissions.write = .*
 
 ## Clustering
 cluster_partition_handling = $RABBITMQ_CLUSTER_PARTITION_HANDLING
-
-## Set a limit relative to total available RAM
-disk_free_limit.relative = $RABBITMQ_DISK_FREE_LIMIT
-
 EOF
+
+    if [[ -n "$RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT" ]]; then
+        cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF
+## Set an absolute disk free space limit
+disk_free_limit.absolute = $RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT
+EOF
+    else
+        cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF
+## Set a limit relative to total available RAM
+disk_free_limit.relative = $RABBITMQ_DISK_FREE_RELATIVE_LIMIT
+EOF
+    fi
 
     if is_boolean_yes "$RABBITMQ_ENABLE_LDAP"; then
         cat >> "${RABBITMQ_CONF_DIR}/rabbitmq.conf" <<EOF

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Available variables:
 * `RABBITMQ_CLUSTER_NODE_NAME`: Node name to cluster with. E.g.: **clusternode@hostname**
 * `RABBITMQ_CLUSTER_PARTITION_HANDLING`: Cluster partition recovery mechanism. Default: **ignore**
 * `RABBITMQ_MANAGER_PORT_NUMBER`: Manager port. Default: **15672**
-* `RABBITMQ_DISK_FREE_LIMIT`: Disk free space limit of the partition on which RabbitMQ is storing data. Default: **{mem_relative, 1.0}**
+* `RABBITMQ_DISK_FREE_RELATIVE_LIMIT`: Disk relative free space limit of the partition on which RabbitMQ is storing data. Default: **1.0**
+* `RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT`: Disk absolute free space limit of the partition on which RabbitMQ is storing data (takes precedence over the relative limit). No defaults.
 * `RABBITMQ_ULIMIT_NOFILES`: Resources limits: maximum number of open file descriptors. Default: **65536**
 * `RABBITMQ_ENABLE_LDAP`: Enable the LDAP configuration. Defaults: **no**
 * `RABBITMQ_LDAP_TLS`: Enable secure LDAP configuration. Defaults: **no**


### PR DESCRIPTION
**Description of the change**

This PR provides a way to configure the Disk Free Limit (see https://www.rabbitmq.com/disk-alarms.html#configure) bot using relative and absolute values.

**Benefits**

Flexibility 

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/bitnami-docker-rabbitmq/issues/124
