### PR TITLE
Fix configuration directory in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,9 @@ volumes:
 
 ### Configuration file
 
-A custom `rabbitmq.conf` configuration file can be mounted to the `/bitnami/rabbitmq/conf/rabbitmq` directory. If no file is mounted, the container will generate a default one based on the environment variables. You can also moun on this directory your own `advanced.config` (using classic Erlang terms) and `rabbitmq-env.conf` configuration files.
+A custom `rabbitmq.conf` configuration file can be mounted to the `/bitnami/rabbitmq/conf` directory. If no file is mounted, the container will generate a default one based on the environment variables. You can also moun on this directory your own `advanced.config` (using classic Erlang terms) and `rabbitmq-env.conf` configuration files.
 
-As an alternative, you can also mount a `custom.conf` configuration file and mount it to the `/bitnami/rabbitmq/conf/rabbitmq` directory. In this case, the default configuation file will be generated and, later on, the settings available in the `custom.conf` configuration file will be merged with the default ones. For example, in order to override the `listeners.tcp.default` directive:
+As an alternative, you can also mount a `custom.conf` configuration file and mount it to the `/bitnami/rabbitmq/conf` directory. In this case, the default configuation file will be generated and, later on, the settings available in the `custom.conf` configuration file will be merged with the default ones. For example, in order to override the `listeners.tcp.default` directive:
 
 #### Step 1: Write your custom.conf configuation file with the following content.
 
@@ -341,7 +341,7 @@ listeners.tcp.default=1337
 
 ```
 $ docker run -d --name rabbitmq-server \
-   -v /path/to/custom.conf:/bitnami/rabbitmq/conf/my_custom.conf:ro \
+   -v /path/to/custom.conf:/bitnami/rabbitmq/conf/custom.conf:ro \
     bitnami/rabbitmq:latest
 ```
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Changes paths to user configuration directory to the correct ones, according to:

- https://github.com/bitnami/bitnami-docker-rabbitmq/blob/master/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh#L40
- https://github.com/bitnami/bitnami-docker-rabbitmq/blob/master/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh#L497

