### PR TITLE
Support not changing password

### DIFF
--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -94,6 +94,10 @@ rabbitmq_validate() {
         error_code=1
     }
 
+    if ! is_yes_no_value "$RABBITMQ_LOAD_DEFINITIONS"; then
+        print_validation_error "An invalid value was specified in the environment variable RABBITMQ_LOAD_DEFINITIONS. Valid values are: yes or no"
+    fi
+
     if ! is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS" && [[ -z "$RABBITMQ_PASSWORD" ]]; then
         print_validation_error "You must indicate a password or a hashed password."
     fi

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -53,7 +53,7 @@ export RABBITMQ_CLUSTER_PARTITION_HANDLING="${RABBITMQ_CLUSTER_PARTITION_HANDLIN
 export RABBITMQ_DISK_FREE_RELATIVE_LIMIT="${RABBITMQ_DISK_FREE_RELATIVE_LIMIT:-1.0}"
 export RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT="${RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT:-}"
 export RABBITMQ_ERL_COOKIE="${RABBITMQ_ERL_COOKIE:-}"
-export RABBITMQ_LOAD_DEFINITIONS=${RABBITMQ_LOAD_DEFINITIONS:-}
+export RABBITMQ_LOAD_DEFINITIONS=${RABBITMQ_LOAD_DEFINITIONS:-no}
 export RABBITMQ_MANAGER_BIND_IP="${RABBITMQ_MANAGER_BIND_IP:-0.0.0.0}"
 export RABBITMQ_MANAGER_PORT_NUMBER="${RABBITMQ_MANAGER_PORT_NUMBER:-15672}"
 export RABBITMQ_NODE_NAME="${RABBITMQ_NODE_NAME:-rabbit@localhost}"
@@ -94,7 +94,7 @@ rabbitmq_validate() {
         error_code=1
     }
 
-    if [[ -z "$RABBITMQ_LOAD_DEFINITIONS" && -z "$RABBITMQ_PASSWORD" ]]; then
+    if is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS" && [[ -z "$RABBITMQ_PASSWORD" ]]; then
         print_validation_error "You must indicate a password or a hashed password."
     fi
     
@@ -523,7 +523,7 @@ rabbitmq_initialize() {
     else
         ! is_rabbitmq_running && rabbitmq_start_bg
 
-        if [[ -z "$RABBITMQ_LOAD_DEFINITIONS" ]]; then
+        if is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS"; then
             rabbitmq_change_password "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
         fi
         if [[ "$RABBITMQ_NODE_TYPE" != "stats" ]] && [[ -n "$RABBITMQ_CLUSTER_NODE_NAME" ]]; then

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -94,6 +94,10 @@ rabbitmq_validate() {
         error_code=1
     }
 
+    if [[ -z "$RABBITMQ_LOAD_DEFINITIONS" ]] && [[ -z "$RABBITMQ_PASSWORD" ]]; then
+        print_validation_error "You must indicate a password or a hashed password."
+    fi
+    
     if ! is_yes_no_value "$RABBITMQ_ENABLE_LDAP"; then
         print_validation_error "An invalid value was specified in the environment variable RABBITMQ_ENABLE_LDAP. Valid values are: yes or no"
     fi
@@ -519,7 +523,7 @@ rabbitmq_initialize() {
     else
         ! is_rabbitmq_running && rabbitmq_start_bg
 
-        if [ -z "$RABBITMQ_LOAD_DEFINITIONS" ]; then
+        if [[ -z "$RABBITMQ_LOAD_DEFINITIONS" ]]; then
             rabbitmq_change_password "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
         fi
         if [[ "$RABBITMQ_NODE_TYPE" != "stats" ]] && [[ -n "$RABBITMQ_CLUSTER_NODE_NAME" ]]; then

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -94,7 +94,7 @@ rabbitmq_validate() {
         error_code=1
     }
 
-    if is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS" && [[ -z "$RABBITMQ_PASSWORD" ]]; then
+    if ! is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS" && [[ -z "$RABBITMQ_PASSWORD" ]]; then
         print_validation_error "You must indicate a password or a hashed password."
     fi
     
@@ -523,7 +523,7 @@ rabbitmq_initialize() {
     else
         ! is_rabbitmq_running && rabbitmq_start_bg
 
-        if is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS"; then
+        if ! is_boolean_yes "$RABBITMQ_LOAD_DEFINITIONS"; then
             rabbitmq_change_password "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
         fi
         if [[ "$RABBITMQ_NODE_TYPE" != "stats" ]] && [[ -n "$RABBITMQ_CLUSTER_NODE_NAME" ]]; then

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -53,7 +53,7 @@ export RABBITMQ_CLUSTER_PARTITION_HANDLING="${RABBITMQ_CLUSTER_PARTITION_HANDLIN
 export RABBITMQ_DISK_FREE_RELATIVE_LIMIT="${RABBITMQ_DISK_FREE_RELATIVE_LIMIT:-1.0}"
 export RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT="${RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT:-}"
 export RABBITMQ_ERL_COOKIE="${RABBITMQ_ERL_COOKIE:-}"
-export RABBITMQ_HASHED_PASSWORD="${RABBITMQ_HASHED_PASSWORD:-}"
+export RABBITMQ_LOAD_DEFINITIONS=${RABBITMQ_LOAD_DEFINITIONS:-}
 export RABBITMQ_MANAGER_BIND_IP="${RABBITMQ_MANAGER_BIND_IP:-0.0.0.0}"
 export RABBITMQ_MANAGER_PORT_NUMBER="${RABBITMQ_MANAGER_PORT_NUMBER:-15672}"
 export RABBITMQ_NODE_NAME="${RABBITMQ_NODE_NAME:-rabbit@localhost}"
@@ -93,14 +93,6 @@ rabbitmq_validate() {
         error "$1"
         error_code=1
     }
-
-    if [[ -z "$RABBITMQ_PASSWORD" && -z "$RABBITMQ_HASHED_PASSWORD" ]]; then
-        print_validation_error "You must indicate a password or a hashed password."
-    fi
-
-    if [[ -n "$RABBITMQ_PASSWORD" && -n "$RABBITMQ_HASHED_PASSWORD" ]]; then
-        warn "You initialized RabbitMQ indicating both a password and a hashed password. Please note only the hashed password will be considered."
-    fi
 
     if ! is_yes_no_value "$RABBITMQ_ENABLE_LDAP"; then
         print_validation_error "An invalid value was specified in the environment variable RABBITMQ_ENABLE_LDAP. Valid values are: yes or no"
@@ -527,7 +519,9 @@ rabbitmq_initialize() {
     else
         ! is_rabbitmq_running && rabbitmq_start_bg
 
-        rabbitmq_change_password "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
+        if [ -z "$RABBITMQ_LOAD_DEFINITIONS" ]; then
+            rabbitmq_change_password "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
+        fi
         if [[ "$RABBITMQ_NODE_TYPE" != "stats" ]] && [[ -n "$RABBITMQ_CLUSTER_NODE_NAME" ]]; then
             rabbitmq_join_cluster "$RABBITMQ_CLUSTER_NODE_NAME" "$RABBITMQ_NODE_TYPE"
         fi

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -94,7 +94,7 @@ rabbitmq_validate() {
         error_code=1
     }
 
-    if [[ -z "$RABBITMQ_LOAD_DEFINITIONS" ]] && [[ -z "$RABBITMQ_PASSWORD" ]]; then
+    if [[ -z "$RABBITMQ_LOAD_DEFINITIONS" && -z "$RABBITMQ_PASSWORD" ]]; then
         print_validation_error "You must indicate a password or a hashed password."
     fi
     

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Available variables:
 
 * `RABBITMQ_USERNAME`: RabbitMQ application username. Default: **user**
 * `RABBITMQ_PASSWORD`: RabbitMQ application password. Default: **bitnami**
-* `RABBITMQ_HASHED_PASSWORD`: RabbitMQ application hashed password.
 * `RABBITMQ_VHOST`: RabbitMQ application vhost. Default: **/**
 * `RABBITMQ_ERL_COOKIE`: Erlang cookie to determine whether different nodes are allowed to communicate with each other.
 * `RABBITMQ_NODE_TYPE`: Node Type. Valid values: *stats*, *queue-ram* or *queue-disc*. Default: **stats**
@@ -210,6 +209,7 @@ Available variables:
 * `RABBITMQ_LDAP_USER_DN_PATTERN`: DN used to bind to LDAP in the form `cn=$${username},dc=example,dc=org`. No defaults.
 * `RABBITMQ_PLUGINS`: Comma, semi-colon or space separated list of plugins to enable during the initialization. No defaults.
 * `RABBITMQ_COMMUNITY_PLUGINS`: Comma, semi-colon or space separated list of URLs where to download custom plugins during the initialization. No defaults.
+* `RABBITMQ_LOAD_DEFINITIONS`: Enable compability with loading external definitions. Currently means that password for `RABBITMQ_USERNAME` is not changed to `RABBITMQ_PASSWORD`. Default: **no**.
 
 ### Setting up a cluster
 
@@ -503,11 +503,6 @@ $ docker-compose up rabbitmq
 
 * Decrease the size of the container. Node.js is not needed anymore. RabbitMQ configuration logic has been moved to bash scripts in the `rootfs` folder.
 * Configuration is not persisted anymore.
-
-### 3.7.7-r35
-
-* The RabbitMQ container includes a new environment variable `RABBITMQ_HASHED_PASSWORD` that allows setting password via SHA256 hash (consult [official documentation](https://www.rabbitmq.com/passwords.html) for more information about password hashes).
-* Please note that password hashes must be generated following the [official algorithm](https://www.rabbitmq.com/passwords.html#computing-password-hash). You can use [this Python script](https://gist.githubusercontent.com/anapsix/4c3e8a8685ce5a3f0d7599c9902fd0d5/raw/1203a480fcec1982084b3528415c3cad26541b82/rmq_passwd_hash.py) to generate them.
 
 ### 3.7.7-r19
 

--- a/README.md
+++ b/README.md
@@ -487,6 +487,14 @@ $ docker-compose up rabbitmq
 
 ## Notable changes
 
+### 3.8.9-debian-10-r34
+
+* The environment variable `RABBITMQ_HASHED_PASSWORD` has not been used for some time. It is now
+  removed from documentation anv validation.
+* New boolean environment variable `RABBITMQ_LOAD_DEFINITIONS` to get behavior compatible with using
+  the `load_definitions` configuration. Initially this means that the password of
+  `RABBITMQ_USERNAME` is not changed using `rabbitmqctl change_password`.
+
 ### 3.8.3-debian-10-r109
 
 * The default configuration file is created following the "sysctl" or "ini-like" format instead of using Erlang terms. Check [Official documentation](https://www.rabbitmq.com/configure.html#config-file-formats) for more information about supported formats.
@@ -503,6 +511,11 @@ $ docker-compose up rabbitmq
 
 * Decrease the size of the container. Node.js is not needed anymore. RabbitMQ configuration logic has been moved to bash scripts in the `rootfs` folder.
 * Configuration is not persisted anymore.
+
+### 3.7.7-r35
+
+* The RabbitMQ container includes a new environment variable `RABBITMQ_HASHED_PASSWORD` that allows setting password via SHA256 hash (consult [official documentation](https://www.rabbitmq.com/passwords.html) for more information about password hashes).
+* Please note that password hashes must be generated following the [official algorithm](https://www.rabbitmq.com/passwords.html#computing-password-hash). You can use [this Python script](https://gist.githubusercontent.com/anapsix/4c3e8a8685ce5a3f0d7599c9902fd0d5/raw/1203a480fcec1982084b3528415c3cad26541b82/rmq_passwd_hash.py) to generate them.
 
 ### 3.7.7-r19
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The change allows for RABBITMQ_PASSWORD to not be set and when RABBITMQ_LOAD_DEFINITIONS is set instead the rabbitmq_initialize function won't try to change the password.

**Benefits**

Together with other changes in the bitnami rabbitmq helm chart it will again be possible to load definitions.

**Possible drawbacks**

Any user password needs to be explicitly set in the definition file. If not the password will stay as it is in rabbitmq.conf, which by default is CHANGEME when using the helm chart. In the coming PR for the helm chart I will therefore expand the [documentation for loading definitions](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq#load-definitions) with the requirement to include user credentials in the definitions.  

**Applicable issues**

bitnami/charts#3675

