### PR TITLE
Adding script to use as k8s preStop hook

### DIFF
--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/libhook.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/libhook.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
+
 # Library to use for scripts expected to be used as Kubernetes lifecycle hooks
 
 # Output is sent to output of process 1 and thus end up in the container log. The hook output in

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/libhook.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/libhook.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Library to use for scripts expected to be used as Kubernetes lifecycle hooks
+
+# Output is sent to output of process 1 and thus end up in the container log. The hook output in
+# general isn't saved.
+
+. /opt/bitnami/scripts/liblog.sh
+########################
+# Print to STDERR of process 1. Overrides implementation in liblog.
+# Arguments:
+#   Message to print
+# Returns:
+#   None
+#########################
+stderr_print() {
+    # 'is_boolean_yes' is defined in libvalidations.sh, but depends on this file so we cannot source it
+    local bool="${BITNAMI_QUIET:-false}"
+    # comparison is performed without regard to the case of alphabetic characters
+    shopt -s nocasematch
+    if ! [[ "$bool" = 1 || "$bool" =~ ^(yes|true)$ ]]; then
+        printf "%b\\n" "${*}" >/proc/1/fd/2
+    fi
+}
+#########################
+# Redirects output to /dev/null if debug mode is disabled and to output of process 1 otherwise.
+# Globals:
+#   BITNAMI_DEBUG
+# Arguments:
+#   $@ - Command to execute
+# Returns:
+#   None
+#########################
+debug_execute() {
+    if ${BITNAMI_DEBUG:-false}; then
+        "$@" >/proc/1/fd/1 2>/proc/1/fd/2
+    else
+        "$@" >/dev/null 2>&1
+    fi
+}

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
@@ -4,6 +4,7 @@
 
 set -o nounset
 
+. /opt/bitnami/scripts/liblog.sh
 . /opt/bitnami/scripts/libhook.sh
 
 while getopts t:d:h flag
@@ -30,7 +31,7 @@ do
 	esac
 done
 
-if [[ "${TERMINATION_GRACE_PERIOD_SECONDS:-x}" =~ ^[0-9]+$ ]]; then
+if [[ "${TERMINATION_GRACE_PERIOD_SECONDS:-}" =~ ^[0-9]+$ ]]; then
     RABBITMQ_SYNC_TIMEOUT=$((TERMINATION_GRACE_PERIOD_SECONDS - 10))
 else
     RABBITMQ_SYNC_TIMEOUT=0

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
@@ -9,11 +9,11 @@ set -o nounset
 
 while getopts t:d:h flag
 do
-	case "${flag}" in
-	    t)
+    case "${flag}" in
+        t)
             TERMINATION_GRACE_PERIOD_SECONDS=${OPTARG}
             ;;
-	    d)
+        d)
             export BITNAMI_DEBUG=${OPTARG}
             ;;
         h)
@@ -28,7 +28,7 @@ do
             echo error "Option -$OPTARG requires an argument."
             exit 1
             ;;
-	esac
+    esac
 done
 
 if [[ "${TERMINATION_GRACE_PERIOD_SECONDS:-}" =~ ^[0-9]+$ ]]; then

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
@@ -1,29 +1,47 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
+
 set -o nounset
 
 . /opt/bitnami/scripts/libhook.sh
 
-while getopts t:d: flag
+while getopts t:d:h flag
 do
 	case "${flag}" in
-	    t) TERMINATION_GRACE_PERIOD_SECONDS=${OPTARG};;
-	    d) export BITNAMI_DEBUG=${OPTARG};;
+	    t)
+            TERMINATION_GRACE_PERIOD_SECONDS=${OPTARG}
+            ;;
+	    d)
+            export BITNAMI_DEBUG=${OPTARG}
+            ;;
+        h)
+            info "Usage: $0 [ -t <TERMINATION_GRACE_PERIOD_SECONDS> ] [ -d <DEBUG_BOOLEAN> ]"
+            exit 0
+            ;;
+        \?)
+            error "Invalid option: -$OPTARG"
+            exit 1
+            ;;
+        :)
+            echo error "Option -$OPTARG requires an argument."
+            exit 1
+            ;;
 	esac
 done
 
 if [[ "${TERMINATION_GRACE_PERIOD_SECONDS:-x}" =~ ^[0-9]+$ ]]; then
-    RABBITMQ_SYNC_TIMEOUT=$(($TERMINATION_GRACE_PERIOD_SECONDS - 10))
+    RABBITMQ_SYNC_TIMEOUT=$((TERMINATION_GRACE_PERIOD_SECONDS - 10))
 else
     RABBITMQ_SYNC_TIMEOUT=0
 fi
 
 debug "RABBITMQ_SYNC_TIMEOUT is $RABBITMQ_SYNC_TIMEOUT"
 
-if debug_execute rabbitmqctl cluster_status && [[ $RABBITMQ_SYNC_TIMEOUT > 0 ]]; then
+if debug_execute rabbitmqctl cluster_status && [[ $RABBITMQ_SYNC_TIMEOUT gt 0 ]]; then
     debug "Will wait up to $RABBITMQ_SYNC_TIMEOUT seconds for node to make sure cluster is healthy after node shutdown"
     debug_execute timeout $RABBITMQ_SYNC_TIMEOUT /opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
-    if [ $? -eq 124]; then
+    if [[ $? -eq 124 ]]; then
         warn "Wait for safe node shutdown has timed out. Continuing to node shutdown anyway."
     fi
 fi

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/nodeshutdown.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o nounset
+
+. /opt/bitnami/scripts/libhook.sh
+
+while getopts t:d: flag
+do
+	case "${flag}" in
+	    t) TERMINATION_GRACE_PERIOD_SECONDS=${OPTARG};;
+	    d) export BITNAMI_DEBUG=${OPTARG};;
+	esac
+done
+
+if [[ "${TERMINATION_GRACE_PERIOD_SECONDS:-x}" =~ ^[0-9]+$ ]]; then
+    RABBITMQ_SYNC_TIMEOUT=$(($TERMINATION_GRACE_PERIOD_SECONDS - 10))
+else
+    RABBITMQ_SYNC_TIMEOUT=0
+fi
+
+debug "RABBITMQ_SYNC_TIMEOUT is $RABBITMQ_SYNC_TIMEOUT"
+
+if debug_execute rabbitmqctl cluster_status && [[ $RABBITMQ_SYNC_TIMEOUT > 0 ]]; then
+    debug "Will wait up to $RABBITMQ_SYNC_TIMEOUT seconds for node to make sure cluster is healthy after node shutdown"
+    debug_execute timeout $RABBITMQ_SYNC_TIMEOUT /opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
+    if [ $? -eq 124]; then
+        warn "Wait for safe node shutdown has timed out. Continuing to node shutdown anyway."
+    fi
+fi
+
+rabbitmqctl stop_app

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o nounset
+
+. /opt/bitnami/scripts/libhook.sh
+
+while : ; do
+    waiting="false"
+    if ! debug_execute rabbitmq-diagnostics -q check_if_node_is_mirror_sync_critical; then
+        debug "check_if_node_is_mirror_sync_critical returns error. Continuing to wait"
+        waiting="true"
+    fi
+    if ! debug_execute rabbitmq-diagnostics -q check_if_node_is_quorum_critical; then
+        debug "check_if_node_is_quorum_critical returns error. Continuing to wait"
+        waiting="true"
+    fi
+    if [[ $waiting = "true" ]]; then
+        sleep 1
+    else
+        break
+    fi
+done

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
+
 set -o nounset
 
 . /opt/bitnami/scripts/libhook.sh

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/rabbitmq/waitforsafeshutdown.sh
@@ -4,6 +4,7 @@
 
 set -o nounset
 
+. /opt/bitnami/scripts/liblog.sh
 . /opt/bitnami/scripts/libhook.sh
 
 while : ; do

--- a/README.md
+++ b/README.md
@@ -487,10 +487,13 @@ $ docker-compose up rabbitmq
 
 ## Notable changes
 
+* Add script to be used as preStop hook on K8s environments. It waits until queues have synchronised
+  mirror before shutting down.
+
 ### 3.8.9-debian-10-r42
 
 * The environment variable `RABBITMQ_HASHED_PASSWORD` has not been used for some time. It is now
-  removed from documentation anv validation.
+  removed from documentation and validation.
 * New boolean environment variable `RABBITMQ_LOAD_DEFINITIONS` to get behavior compatible with using
   the `load_definitions` configuration. Initially this means that the password of
   `RABBITMQ_USERNAME` is not changed using `rabbitmqctl change_password`.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adding script `nodeshutdown.sh` to use as k8s preStop hook. The script will wait for the checks `check_if_node_is_mirror_sync_critical` and `check_if_node_is_quorum_critical` to become OK before proceeding to do `stop_app`.

**Benefits**

If you have a cluster with replicated queues with many messages using this script as a  this will reduce the risk for data loss especially when doing a configuration update that require all nodes/containers to be recreated.

**Possible drawbacks**

Stopping the container might take longer.

**Applicable issues**

bitnami/charts#3931
