### PR TITLE
Fixing management IP & Port

### DIFF
--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -226,8 +226,8 @@ rabbitmq_print_networking_configuration() {
 rabbitmq_print_management_configuration() {
     echo "## Management"
     if rabbitmq_is_ssl_enabled "management_ssl"; then
-        echo "management.ssl.port = ${RABBITMQ_MANAGEMENT_BIND_IP}"
-        echo "management.ssl.ip = ${RABBITMQ_MANAGEMENT_SSL_PORT_NUMBER}"
+        echo "management.ssl.ip = ${RABBITMQ_MANAGEMENT_BIND_IP}"
+        echo "management.ssl.port = ${RABBITMQ_MANAGEMENT_SSL_PORT_NUMBER}"
         rabbitmq_print_ssl_configuration "management_ssl" "management.ssl"
     else
         # Assume SSL is disabled when no environment variables matching 'RABBITMQ_SSL_*' have been specified


### PR DESCRIPTION
Changing the wrong variable assignment that I noticed in #148 .
I basically just switched the assigned variables around to correctly assign IP and Port.

**Description of the change**

The change should fix assigning IP and Port for the management server

**Benefits**

The management server was not able to start with an existing SSL configuration before

**Possible drawbacks**

none to my knowledge

**Applicable issues**

#148 

**Additional information**

-
