### PR TITLE
librabbitmq: protect the password from being interpreted as flags

### DIFF
--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -623,7 +623,7 @@ rabbitmq_change_password() {
     local password="${2:?password is required}"
     debug "Changing password for user '${user}'..."
 
-    if ! debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" change_password "$user" "$password"; then
+    if ! debug_execute "${RABBITMQ_BIN_DIR}/rabbitmqctl" change_password -- "$user" "$password"; then
         error "Couldn't change password for user '${user}'."
         return 1
     fi


### PR DESCRIPTION
**Description of the change**

Add `--` to the `change_password` command line to protect the password from being interpreted as a series of command line flags.

**Benefits**

If the password starts with a dash (`-`), it would otherwise be
interpreted as a series of single-character flags by rabbitmqctl,
making the password change fail.

This can be hard to detect because the container will immediately
be restarted and the password change is not retried by the scripts
because the user exists already. So unless you happen to be
watching the logs from the beginning, it can be a very confusing
situation.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

Might be worth revisiting the user creation at some point to delete the user if the password failed to be set, in order to prevent an incorrectly configured container to start up.